### PR TITLE
Fix/10  component category css  fix

### DIFF
--- a/src/components/Category/CategoryItem.tsx
+++ b/src/components/Category/CategoryItem.tsx
@@ -15,11 +15,11 @@ function CategoryItem({ category }: { category: Category }) {
 				},
 				position: 'relative',
 				aspectRatio: '1/1',
-				minWidth: {
-					base: '140px',
-					md: '160px',
-					lg: '180px',
-				},
+				// minWidth: {
+				// 	base: '140px',
+				// 	md: '160px',
+				// 	lg: '180px',
+				// },
 				width: '100%',
 				zIndex: isActive ? '20' : 'auto',
 				transform: 'none',
@@ -84,7 +84,7 @@ function CategoryItem({ category }: { category: Category }) {
 					<div
 						className={css({
 							position: 'absolute',
-							width: '150%',
+							width: '101%',
 							minH: '200px',
 							height: `calc(${category.subCategories.length} * 48px + 80px)`, // 동적 높이 계산
 							maxHeight: {

--- a/src/components/Category/CategoryItem.tsx
+++ b/src/components/Category/CategoryItem.tsx
@@ -114,13 +114,15 @@ function CategoryItem({ category }: { category: Category }) {
 							gap: '8px',
 						})}
 					>
-						<div
+						<Link
+							to={category.route}
 							className={css({
 								display: 'flex',
 								alignItems: 'center',
+								_hover: { bg: 'gray.100' },
 								gap: '12px',
 								pb: '8px',
-								borderBottom: '1px solid #f3f4f6', // 구분선
+								borderBottom: '1px solid #f3f4f6',
 							})}
 						>
 							<div
@@ -144,7 +146,7 @@ function CategoryItem({ category }: { category: Category }) {
 							>
 								{category.name}
 							</span>
-						</div>
+						</Link>
 						{category.subCategories.map((sub) => (
 							<Link
 								key={sub.id}

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -18,8 +18,8 @@ type SubCategory = {
 	route: string;
 };
 const iconStyle = css({
-	width: '128px',
-	height: '128px',
+	width: '40px',
+	height: '40px',
 	strokeWidth: '1.5',
 	color: 'blue.500',
 });
@@ -111,12 +111,12 @@ function Category() {
 		<>
 			<div
 				className={css({
-					display: 'grid',
+					display: { base: 'none', md: 'grid' },
 					gridTemplateColumns: {
-						base: 'repeat(auto-fit, minmax(140px, 1fr))', // 모바일: 더 작은 최소값
-						md: 'repeat(auto-fit, minmax(160px, 1fr))', // 태블릿
-						lg: 'repeat(auto-fit, minmax(180px, 1fr))', // 데스크탑
-						'2xl': 'repeat(7, minmax(180px, 1fr))', // 2xl
+						base: 'repeat(auto-fit, minmax(100px, 1fr))', // 모바일: 더 작은 최소값
+						md: 'repeat(auto-fit, minmax(120px, 1fr))', // 태블릿
+						lg: 'repeat(auto-fit, minmax(140px, 1fr))', // 데스크탑
+						'2xl': 'repeat(7, minmax(140px, 1fr))', // 2xl
 					},
 					gridAutoFlow: 'row',
 					overflow: 'visible',

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -25,15 +25,15 @@ const trends: TrendProps[] = [
 	},
 	{
 		id: '123',
-		title: '소형 원룸을 넓어 보이게 리모델링',
+		title: '트렌드 아이템 2',
 		color: 'gray.800',
 		img: bed02,
 		likes: 15,
 		company: '',
 	},
 	{
-		id: '123',
-		title: '소형 원룸을 넓어 보이게 리모델링',
+		id: '456',
+		title: '트렌드 아이템 3',
 		color: 'gray.800',
 		img: bed03,
 		likes: 15,
@@ -46,10 +46,11 @@ function Trend() {
 		<>
 			<h2
 				className={css({
-					fontSize: '2xl',
+					fontSize: { base: 'xl', md: '2xl' },
 					fontWeight: 'bold',
 					mb: '8',
-					textAlign: 'center',
+					textAlign: { base: 'start', md: 'center' },
+					ml: { base: '8' },
 					height: '30px',
 				})}
 			>
@@ -62,16 +63,29 @@ function Trend() {
 					gridTemplateColumns: {
 						base: 'repeat(1, minmax(280px, 1fr))', // 모바일: 1줄에 1-2개
 						md: 'repeat(2, minmax(320px, 1fr))',
-						xl: 'repeat(auto-fit, minmax(320px, 1fr))',
+						xl: 'repeat(2, minmax(480px, 1fr))',
+						'2xl': 'repeat(3, minmax(480px, 1fr))',
 					},
-					gap: '6',
-					width: '100%',
-					maxWidth: '1440px',
-					height: '400px',
-					mx: 'auto',
+					gap: { base: '2', md: '4', lg: '6' },
+					width: 'calc(100% + 12px)',
+					marginLeft: '-6px',
+					justifyItems: 'center',
+					justifyContent: 'space-evenly',
+					// justifyItems: 'start',
+
+					// alignItems: 'center',
+					// alignContent: 'center',
+					maxWidth: '1580px',
+					height: '600px',
+					// mx: 'auto',
+					mx: { base: '0, 6px', md: 'auto' },
 					overflowX: 'hidden',
-					overflowY: { base: 'auto', xl: 'hidden' }, // 모바일에서 스크롤 가능
+					overflowY: { base: 'auto', '2xl': 'hidden' }, // 모바일에서 스크롤 가능
 					scrollbar: 'hidden',
+					WebkitOverflowScrolling: 'touch',
+					scrollSnapType: 'none',
+					willChange: 'transform',
+					scrollBehavior: 'smooth',
 				})}
 			>
 				{trends.map((item) => (
@@ -80,9 +94,9 @@ function Trend() {
 						className={css({
 							bg: 'white',
 							minH: '350px',
-							width: { base: '100vw', md: 'calc(100% - 12px)' },
-							maxWidth: '640px',
-							height: { base: '400px', md: '360px' },
+							width: { base: '350px', md: 'calc(100% - 24px)', lg: 'calc(100% - 12px)' },
+							maxWidth: '480px',
+							height: { base: '350px', md: '360px' },
 							borderRadius: 'xl',
 							overflow: 'hidden',
 							border: '1px solid token(colors.gray.200)',

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -53,9 +53,9 @@ function Trend() {
 				className={css({
 					fontSize: { base: 'xl', md: '2xl' },
 					fontWeight: 'bold',
-					mb: '8',
+					mb: '4',
 					textAlign: { base: 'start', md: 'center' },
-					ml: { base: '8' },
+					ml: { base: '2' },
 					height: '30px',
 				})}
 			>
@@ -66,27 +66,28 @@ function Trend() {
 				className={css({
 					display: 'grid',
 					gridTemplateColumns: {
-						base: 'repeat(1, minmax(280px, 1fr))', // 모바일: 1줄에 1-2개
+						base: 'repeat(1, minmax(100vw, 1fr))', // 모바일: 1줄에 1-2개
 						md: 'repeat(2, minmax(320px, 1fr))',
-						xl: 'repeat(2, minmax(480px, 1fr))',
+						xl: 'repeat(3, minmax(480px, 1fr))',
 						'2xl': 'repeat(3, minmax(480px, 1fr))',
 					},
-					gap: { base: '2', md: '4', '2xl': '3' },
+					gap: { base: '0', md: '4', '2xl': '2' },
 					// width: 'calc(100% + 12px)',
-					width: { base: '350px', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
-					marginLeft: '-6px',
-					justifyItems: 'center',
-					justifyContent: 'space-evenly',
+					width: { base: '100%', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
+					justifyItems: { base: 'flex-start', md: 'center' },
+					justifyContent: { base: 'flex-start', '2xl': 'space-evenly' },
+					// alignSelf: { base: 'flex-start', '2xl': 'center' },
+					alignSelf: 'center',
 					// justifyItems: 'start',
 					// alignItems: 'center',
 					// alignContent: 'center',
-					maxWidth: '80vw',
+					maxWidth: { base: '100vw', md: '80vw' },
 					// maxWidth: { base: '350px', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
 					height: '600px',
 					// mx: 'auto',
 					mx: { base: '0, 6px', md: 'auto' },
 					overflowX: 'hidden',
-					overflowY: { base: 'auto', '2xl': 'hidden' }, // 모바일에서 스크롤 가능
+					overflowY: { base: 'auto', '2xl': 'hidden' },
 					scrollbar: 'hidden',
 					WebkitOverflowScrolling: 'touch',
 					scrollSnapType: 'none',
@@ -98,11 +99,13 @@ function Trend() {
 					<div
 						key={item.id}
 						className={css({
+							ml: { base: '3', md: '0' },
 							bg: 'white',
 							mt: '4',
+							mb: '4',
 							minH: '350px',
-							width: { base: '350px', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
-							maxWidth: '480px',
+							width: { base: '80vw', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
+							maxWidth: '80vw',
 							height: { base: '350px', md: '360px' },
 							borderRadius: 'xl',
 							overflow: 'hidden',
@@ -117,7 +120,7 @@ function Trend() {
 							className={css({
 								width: '100%',
 								bgSize: 'cover',
-								height: '200px',
+								height: 'calc(58% - 2px)',
 								objectFit: 'cover',
 							})}
 						/>
@@ -161,7 +164,7 @@ function Trend() {
 					</div>
 				))}
 			</div>
-			<div className={flex({ justify: 'center', mt: '6' })}>
+			<div className={flex({ justify: 'center', mt: '4' })}>
 				<button
 					className={css({
 						px: '6',

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -3,6 +3,7 @@ import { flex } from 'styled-system/patterns';
 import bed01 from '@assets/img/bed01.jpg';
 import bed02 from '@assets/img/bed02.jpg';
 import bed03 from '@assets/img/bed03.jpg';
+import { Link, useNavigate } from 'react-router-dom';
 
 export type TrendProps = {
 	id: string;
@@ -21,7 +22,8 @@ const trends: TrendProps[] = [
 		color: 'gray.800',
 		img: bed01,
 		likes: 15,
-		company: '',
+		company: 'A',
+		location: '서울 광진구',
 	},
 	{
 		id: '123',
@@ -29,7 +31,8 @@ const trends: TrendProps[] = [
 		color: 'gray.800',
 		img: bed02,
 		likes: 15,
-		company: '',
+		company: 'B',
+		location: '경기도 수원시',
 	},
 	{
 		id: '456',
@@ -37,11 +40,13 @@ const trends: TrendProps[] = [
 		color: 'gray.800',
 		img: bed03,
 		likes: 15,
-		company: '',
+		company: 'C',
+		location: '전라북도 전주시',
 	},
 ];
 
 function Trend() {
+	const navigate = useNavigate();
 	return (
 		<>
 			<h2
@@ -66,16 +71,17 @@ function Trend() {
 						xl: 'repeat(2, minmax(480px, 1fr))',
 						'2xl': 'repeat(3, minmax(480px, 1fr))',
 					},
-					gap: { base: '2', md: '4', lg: '6' },
-					width: 'calc(100% + 12px)',
+					gap: { base: '2', md: '4', '2xl': '3' },
+					// width: 'calc(100% + 12px)',
+					width: { base: '350px', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
 					marginLeft: '-6px',
 					justifyItems: 'center',
 					justifyContent: 'space-evenly',
 					// justifyItems: 'start',
-
 					// alignItems: 'center',
 					// alignContent: 'center',
-					maxWidth: '1580px',
+					maxWidth: '80vw',
+					// maxWidth: { base: '350px', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
 					height: '600px',
 					// mx: 'auto',
 					mx: { base: '0, 6px', md: 'auto' },
@@ -93,8 +99,9 @@ function Trend() {
 						key={item.id}
 						className={css({
 							bg: 'white',
+							mt: '4',
 							minH: '350px',
-							width: { base: '350px', md: 'calc(100% - 24px)', lg: 'calc(100% - 12px)' },
+							width: { base: '350px', md: 'calc(100% - 24px)', '2xl': 'calc(100% - 12px)' },
 							maxWidth: '480px',
 							height: { base: '350px', md: '360px' },
 							borderRadius: 'xl',
@@ -141,9 +148,11 @@ function Trend() {
 										bg: 'blue.500',
 										color: 'white',
 										borderRadius: 'full',
+										border: 'none',
 										fontSize: 'sm',
-										_hover: { bg: 'blue.600' },
+										_hover: { bg: 'blue.600', cursor: 'pointer' },
 									})}
+									onClick={() => navigate(`/trend/${item.id}`)}
 								>
 									상세보기
 								</button>
@@ -159,9 +168,12 @@ function Trend() {
 						border: '1px solid token(colors.gray.300)',
 						borderRadius: 'full',
 						fontWeight: 'medium',
-						_hover: { bg: 'gray.100' },
+						_hover: { bg: 'gray.100', cursor: 'pointer' },
 						height: '40px',
 					})}
+					onClick={() => {
+						navigate('/trends');
+					}}
 				>
 					더 많은 사례 보기 →
 				</button>

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -70,7 +70,8 @@ function Trend() {
 					height: '400px',
 					mx: 'auto',
 					overflowX: 'hidden',
-					overflowY: { base: 'auto', md: 'hidden' }, // 모바일에서 스크롤 가능
+					overflowY: { base: 'auto', xl: 'hidden' }, // 모바일에서 스크롤 가능
+					scrollbar: 'hidden',
 				})}
 			>
 				{trends.map((item) => (
@@ -80,6 +81,7 @@ function Trend() {
 							bg: 'white',
 							minH: '350px',
 							width: { base: '100vw', md: 'calc(100% - 12px)' },
+							maxWidth: '640px',
 							height: { base: '400px', md: '360px' },
 							borderRadius: 'xl',
 							overflow: 'hidden',

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -29,11 +29,8 @@ function Home() {
 				{/* 트렌드 섹션 ( 추가 ) */}
 				<section
 					className={flex({
-						height: { base: '400px', md: '600px' }, // maxHeight → height
-						minHeight: '500px', // 최소 높이 보장
 						flexDirection: 'column',
 						position: 'relative', // 자식 요소 제어용
-						overflow: 'hidden', // 내용물 넘침 방지
 					})}
 				>
 					<Trend />

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -54,6 +54,7 @@ function Home() {
 					className={css({
 						mx: 'auto',
 						py: { base: '8', md: '16' },
+						width: '100vw',
 						px: { base: '4', md: '6' },
 					})}
 				>


### PR DESCRIPTION
### 연관된 이슈

> #19 , #20 

### 작업 내용

> 카테고리 컴포넌트의 크기 수정 및 #20 의 대분류 Link 추가
 - 드랍다운 크기 수정(150% > 101%)
 - 아이콘 크기 수정(128 > 40)
 - 모바일 환경에선 display:none(다른 방식으로 분류 보여주기 예정, 버튼형태는 너무 길어짐)
 - 반응형 정렬 수정

> 트렌드 컴포넌트의 반응형 동작 수정
 -  모바일 환경에서 스크롤 동작 & 모습은 안보이게 수정
 - 반응형 동작 시, 복수의 줄로 변경될 때 가운데 정렬 및 마진 등 공간 전체적으로 수정(~lg)
 - 스크롤 동작 시 부드럽게 움직이도록 수정
 - 모바일 환경에서 1열로 정렬될 때 자연스러워지도록 정렬 및 공간 수정

> #20 Link 동작 수정
  - 트렌드 버튼(상세보기, 더 알아보기 버튼)
  - 카테고리/드랍다운 대분류에 Link 추가 

### 스크린샷 (선택)
<img width="1735" height="900" alt="image" src="https://github.com/user-attachments/assets/3ae07f38-25a1-4733-9cb5-30ab56249d05" />
<img width="1056" height="511" alt="image" src="https://github.com/user-attachments/assets/27e266c3-c021-41bc-88af-c83eaceb6638" />
<img width="327" height="593" alt="image" src="https://github.com/user-attachments/assets/2e75d0fa-7093-45d9-b380-c9e01db0f984" />



### 리뷰 요구사항(선택)

> CSS 정리가 필요해보임...
