### PR TITLE
Feat/62--detail-item-page-add

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
 
 import Navigation from './components/Navigation';
+import DetailItem from './pages/detailItem';
 import Home from './pages/Home';
 
 const App = () => {
@@ -8,6 +9,7 @@ const App = () => {
 		<Routes>
 			<Route element={<Navigation />}>
 				<Route path='/' element={<Home />} />
+				<Route path='/work/:id' element={<DetailItem />} />
 			</Route>
 		</Routes>
 	);

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -51,7 +51,7 @@ const Trend = () => {
 											<span className={css({ color: 'amber.600', fontWeight: 'bold' })}>
 												♥ {item.likes}
 											</span>
-											<Link className={trendStyles.detailButton} to={`/trend/${item.id}`}>
+											<Link className={trendStyles.detailButton} to={`/work/${item.id}`}>
 												상세보기
 											</Link>
 										</div>

--- a/src/components/detailBoard/index.tsx
+++ b/src/components/detailBoard/index.tsx
@@ -1,0 +1,68 @@
+import { Clock, DollarSign, MapPin } from 'lucide-react';
+
+import type { PortfolioItem } from '@/assets/data/type';
+
+import { detailBoardStyles } from './styles';
+
+interface DetailBoardProps {
+	data: PortfolioItem | null;
+}
+
+const DetailBoard = ({ data }: DetailBoardProps) => {
+	return (
+		<div className={detailBoardStyles.mainContent}>
+			{data && (
+				<>
+					<h1 className={detailBoardStyles.title}>{data.title}</h1>
+					<p className={detailBoardStyles.description}>{data.description}</p>
+					<div className={detailBoardStyles.tagContainer}>
+						{data.tags.map((tag, index) => (
+							<span key={`${data.tags[index]}tags`} className={detailBoardStyles.tag}>
+								#{tag}
+							</span>
+						))}
+					</div>
+					<div className={detailBoardStyles.detailCard}>
+						<h2 className={detailBoardStyles.detailTitle}>상세 정보</h2>
+						<div className={detailBoardStyles.detailGrid}>
+							<div className={detailBoardStyles.detailItem}>
+								<MapPin size={20} className={detailBoardStyles.detailIcon} />
+								<span>{data.details.location}</span>
+							</div>
+							<div className={detailBoardStyles.detailItem}>
+								<div className={detailBoardStyles.detailIcon}>㎡</div>
+								<span>{data.details.area}평</span>
+							</div>
+							<div className={detailBoardStyles.detailItem}>
+								<Clock size={20} className={detailBoardStyles.detailIcon} />
+								<span>{data.details.period}</span>
+							</div>
+							<div className={detailBoardStyles.detailItem}>
+								<DollarSign size={20} className={detailBoardStyles.detailIcon} />
+								<span>{data.details.budget.toLocaleString()}만원</span>
+							</div>
+						</div>
+						<div className={detailBoardStyles.materialsContainer}>
+							<h3 className={detailBoardStyles.materialsTitle}>사용 재료</h3>
+							<div className={detailBoardStyles.materialsList}>
+								{data.details.materials.map((material, index) => (
+									<span
+										key={`${data.details.materials[index]}mat`}
+										className={detailBoardStyles.materialTag}
+									>
+										{material}
+									</span>
+								))}
+							</div>
+						</div>
+					</div>
+					<div className={detailBoardStyles.storySection}>
+						<h2 className={detailBoardStyles.storyTitle}>리모델링 스토리</h2>
+						<p className={detailBoardStyles.storyText}>게시글 게시글 게시글</p>
+					</div>
+				</>
+			)}
+		</div>
+	);
+};
+export default DetailBoard;

--- a/src/components/detailBoard/styles.ts
+++ b/src/components/detailBoard/styles.ts
@@ -1,0 +1,87 @@
+import { css } from 'styled-system/css';
+
+export const detailBoardStyles = {
+	mainContent: css({
+		spaceY: '6',
+	}),
+	title: css({
+		fontSize: '3xl',
+		fontWeight: 'bold',
+	}),
+	description: css({
+		color: 'gray.600',
+	}),
+	tagContainer: css({
+		display: 'flex',
+		flexWrap: 'wrap',
+		gap: '2',
+	}),
+	tag: css({
+		px: '3',
+		py: '1',
+		bg: 'gray.100',
+		color: 'gray.700',
+		borderRadius: 'full',
+		fontSize: 'sm',
+	}),
+	detailCard: css({
+		bg: 'gray.50',
+		p: '6',
+		borderRadius: 'lg',
+	}),
+	detailTitle: css({
+		fontSize: 'xl',
+		fontWeight: 'semibold',
+		mb: '4',
+	}),
+	detailGrid: css({
+		display: 'grid',
+		gridTemplateColumns: {
+			base: '1fr',
+			md: '1fr 1fr',
+		},
+		gap: '4',
+	}),
+	detailItem: css({
+		display: 'flex',
+		alignItems: 'center',
+	}),
+	detailIcon: css({
+		color: 'gray.500',
+		mr: '2',
+	}),
+	materialsContainer: css({
+		mt: '4',
+	}),
+	materialsTitle: css({
+		fontWeight: 'medium',
+		color: 'gray.700',
+		mb: '2',
+	}),
+	materialsList: css({
+		display: 'flex',
+		flexWrap: 'wrap',
+		gap: '2',
+	}),
+	materialTag: css({
+		px: '3',
+		py: '1',
+		bg: 'white',
+		border: '1px solid',
+		borderColor: 'gray.200',
+		borderRadius: 'full',
+		fontSize: 'sm',
+	}),
+	storySection: css({
+		maxW: 'none',
+	}),
+	storyTitle: css({
+		fontSize: 'xl',
+		fontWeight: 'semibold',
+		mb: '4',
+	}),
+	storyText: css({
+		color: 'gray.700',
+		mb: '4',
+	}),
+};

--- a/src/components/detailSidebar/companyCard.tsx
+++ b/src/components/detailSidebar/companyCard.tsx
@@ -1,0 +1,39 @@
+import type { PortfolioItem } from '@/assets/data/type';
+
+import { detailSidebarStyles } from './styles';
+
+interface CompanyCardProps {
+	data: PortfolioItem | null;
+}
+
+const CompanyCard = ({ data }: CompanyCardProps) => {
+	return (
+		<div className={detailSidebarStyles.companyCard}>
+			{data && (
+				<>
+					<div className={detailSidebarStyles.companyInfo}>
+						<img
+							src={data.company.logo}
+							alt={data.company.name}
+							className={detailSidebarStyles.companyLogo}
+						/>
+						<div>
+							<h3 className={detailSidebarStyles.companyName}>{data.company.name}</h3>
+							<div className={detailSidebarStyles.companyRating}>
+								<span className={detailSidebarStyles.ratingStar}>★</span>
+								<span className={detailSidebarStyles.ratingValue}>{data.company.rating}</span>
+								<span className={detailSidebarStyles.ratingCount}>
+									({data.company.reviewCount} reviews)
+								</span>
+							</div>
+						</div>
+					</div>
+					<button type='button' className={detailSidebarStyles.inquiryButton}>
+						문의하기
+					</button>
+				</>
+			)}
+		</div>
+	);
+};
+export default CompanyCard;

--- a/src/components/detailSidebar/index.tsx
+++ b/src/components/detailSidebar/index.tsx
@@ -1,0 +1,25 @@
+import type { PortfolioItem } from '@/assets/data/type';
+
+import CompanyCard from './companyCard';
+import Metrics from './metrics';
+import Relate from './relate';
+import { detailSidebarStyles } from './styles';
+
+interface DetailSidebarProps {
+	data: PortfolioItem | null;
+}
+
+const DetailSidebar = ({ data }: DetailSidebarProps) => {
+	return (
+		<div className={detailSidebarStyles.sidebar}>
+			{data && (
+				<>
+					<CompanyCard data={data} />
+					<Metrics data={data} />
+					<Relate />
+				</>
+			)}
+		</div>
+	);
+};
+export default DetailSidebar;

--- a/src/components/detailSidebar/metrics.tsx
+++ b/src/components/detailSidebar/metrics.tsx
@@ -1,0 +1,67 @@
+import { Bookmark, Calendar, Eye, Heart, Share } from 'lucide-react';
+import { useState } from 'react';
+
+import type { PortfolioItem } from '@/assets/data/type';
+
+import { detailSidebarStyles } from './styles';
+
+interface MetricsProps {
+	data: PortfolioItem | null;
+}
+
+const Metrics = ({ data }: MetricsProps) => {
+	const [isLiked, setIsLiked] = useState(false);
+	const [isSaved, setIsSaved] = useState(false);
+
+	return (
+		<div className={detailSidebarStyles.metricsCard}>
+			{data && (
+				<>
+					<div className={detailSidebarStyles.metricsButtons}>
+						<button
+							type='button'
+							onClick={() => setIsLiked(!isLiked)}
+							className={detailSidebarStyles.metricButton}
+							style={{ color: isLiked ? '#ef4444' : '#6b7280' }}
+						>
+							<Heart
+								size={20}
+								fill={isLiked ? 'currentColor' : 'none'}
+								className={detailSidebarStyles.metricIcon}
+							/>
+							<span>{data.metrics.likes + (isLiked ? 1 : 0)}</span>
+						</button>
+						<button type='button' className={detailSidebarStyles.metricButton}>
+							<Eye size={20} className={detailSidebarStyles.metricIcon} />
+							<span>{data.metrics.views}</span>
+						</button>
+						<button type='button' className={detailSidebarStyles.metricButton}>
+							<Share size={20} className={detailSidebarStyles.metricIcon} />
+							<span>{data.metrics.shares}</span>
+						</button>
+						<button
+							type='button'
+							onClick={() => setIsSaved(!isSaved)}
+							className={detailSidebarStyles.metricButton}
+							style={{ color: isSaved ? '#3b82f6' : '#6b7280' }}
+						>
+							<Bookmark
+								size={20}
+								fill={isSaved ? 'currentColor' : 'none'}
+								className={detailSidebarStyles.metricIcon}
+							/>
+							<span>{data.metrics.saves + (isSaved ? 1 : 0)}</span>
+						</button>
+					</div>
+
+					<div className={detailSidebarStyles.dateInfo}>
+						<Calendar size={16} className={detailSidebarStyles.dateIcon} />
+						{new Date(data.createdAt).toLocaleDateString('ko-KR')} 게시됨
+					</div>
+				</>
+			)}
+		</div>
+	);
+};
+
+export default Metrics;

--- a/src/components/detailSidebar/relate.tsx
+++ b/src/components/detailSidebar/relate.tsx
@@ -1,0 +1,26 @@
+import { detailPageStyles } from '@/pages/detailItem/styles';
+
+const Relate = () => {
+	return (
+		<div className={detailPageStyles.relatedContent}>
+			<h3 className={detailPageStyles.relatedTitle}>비슷한 인테리어</h3>
+			<div className={detailPageStyles.relatedList}>
+				<div className={detailPageStyles.relatedItem}>
+					<div className={detailPageStyles.relatedImage} />
+					<div className={detailPageStyles.relatedContentInfo}>
+						<p className={detailPageStyles.relatedContentTitle}>소형 주방 공간 활용법</p>
+						<p className={detailPageStyles.relatedContentViews}>n,nnnn views</p>
+					</div>
+				</div>
+				<div className={detailPageStyles.relatedItem}>
+					<div className={detailPageStyles.relatedImage} />
+					<div className={detailPageStyles.relatedContentInfo}>
+						<p className={detailPageStyles.relatedContentTitle}>원룸 수납 아이디어</p>
+						<p className={detailPageStyles.relatedContentViews}>987 views</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+export default Relate;

--- a/src/components/detailSidebar/styles.ts
+++ b/src/components/detailSidebar/styles.ts
@@ -1,0 +1,115 @@
+import { css } from 'styled-system/css';
+
+export const detailSidebarStyles = {
+	sidebar: css({
+		spaceY: '6',
+	}),
+	companyCard: css({
+		bg: 'white',
+		border: '1px solid',
+		borderColor: 'gray.200',
+		borderRadius: 'lg',
+		p: '5',
+	}),
+	companyInfo: css({
+		display: 'flex',
+		alignItems: 'center',
+		mb: '4',
+	}),
+	companyLogo: css({
+		w: '12',
+		h: '12',
+		borderRadius: 'full',
+		objectFit: 'cover',
+		mr: '3',
+	}),
+	companyName: css({
+		fontWeight: 'semibold',
+	}),
+	companyRating: css({
+		display: 'flex',
+		alignItems: 'center',
+	}),
+	ratingStar: css({
+		color: 'yellow.500',
+	}),
+	ratingValue: css({
+		color: 'gray.700',
+		ml: '1',
+	}),
+	ratingCount: css({
+		color: 'gray.500',
+		ml: '2',
+	}),
+	inquiryButton: css({
+		w: 'full',
+		py: '2',
+		bg: 'blue.600',
+		color: 'white',
+		borderRadius: 'lg',
+		fontWeight: 'medium',
+		_hover: {
+			bg: 'blue.700',
+		},
+	}),
+	metricsCard: css({
+		bg: 'white',
+		border: '1px solid',
+		borderColor: 'gray.200',
+		borderRadius: 'lg',
+		p: '5',
+	}),
+	metricsButtons: css({
+		display: 'flex',
+		justifyContent: 'space-between',
+		mb: '4',
+	}),
+	metricButton: css({
+		display: 'flex',
+		alignItems: 'center',
+	}),
+	metricIcon: css({
+		mr: '2',
+	}),
+	dateInfo: css({
+		fontSize: 'sm',
+		color: 'gray.500',
+	}),
+	dateIcon: css({
+		display: 'inline',
+		mr: '1',
+	}),
+	relatedContent: css({
+		bg: 'gray.100',
+		borderRadius: 'lg',
+		p: '5',
+	}),
+	relatedTitle: css({
+		fontWeight: 'semibold',
+		mb: '3',
+	}),
+	relatedList: css({
+		spaceY: '3',
+	}),
+	relatedItem: css({
+		display: 'flex',
+	}),
+	relatedImage: css({
+		w: '16',
+		h: '16',
+		bg: 'gray.300',
+		borderRadius: 'md',
+		flexShrink: '0',
+	}),
+	relatedContentInfo: css({
+		ml: '3',
+	}),
+	relatedContentTitle: css({
+		fontSize: 'sm',
+		fontWeight: 'medium',
+	}),
+	relatedContentViews: css({
+		fontSize: 'xs',
+		color: 'gray.500',
+	}),
+};

--- a/src/components/detailSlider/index.tsx
+++ b/src/components/detailSlider/index.tsx
@@ -1,0 +1,151 @@
+import { ErrorBoundary, Suspense } from '@suspensive/react';
+import { useRef, useState } from 'react';
+
+import type { ImageData } from '@/assets/data/type';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { css } from 'styled-system/css';
+
+import { ErrorFallback } from '../common/fallback';
+import { Skeleton } from '../common/skeleton';
+
+import { detailSliderStyles } from './styles';
+
+const TRANSITION_MS = 500;
+
+interface DetailSliderProps {
+	imageDatas: ImageData[] | null;
+}
+
+const DetailSlider = ({ imageDatas }: DetailSliderProps) => {
+	const refCallback = useIntersectionObserver();
+
+	const slides = imageDatas || [];
+	const [current, setCurrent] = useState(0);
+	const [isTransitionEnabled, setIsTransitionEnabled] = useState(true);
+
+	const [isDragging, setIsDragging] = useState(false);
+	const [dragDelta, setDragDelta] = useState(0);
+
+	const viewportRef = useRef<HTMLDivElement | null>(null);
+	const dragStartX = useRef(0);
+
+	const [isLoading, setIsLoading] = useState(true);
+
+	const getViewportWidth = () => viewportRef.current?.clientWidth ?? 0;
+
+	const handleNext = () => {
+		setIsTransitionEnabled(true);
+		setCurrent((prev) => (prev >= slides.length - 1 ? 0 : prev + 1));
+	};
+
+	const handlePrev = () => {
+		setIsTransitionEnabled(true);
+		setCurrent((prev) => (prev <= 0 ? slides.length - 1 : prev - 1));
+	};
+
+	const onPointerDown = (e: React.PointerEvent) => {
+		(e.currentTarget as Element).setPointerCapture(e.pointerId);
+		setIsDragging(true);
+		dragStartX.current = e.clientX;
+		setDragDelta(0);
+		setIsTransitionEnabled(false);
+	};
+
+	const onPointerMove = (e: React.PointerEvent) => {
+		if (!isDragging) return;
+		const delta = e.clientX - dragStartX.current;
+		setDragDelta(delta);
+	};
+
+	const onPointerUp = (e: React.PointerEvent) => {
+		try {
+			(e.currentTarget as Element).releasePointerCapture(e.pointerId);
+		} catch (err) {
+			console.error(err);
+		}
+		setIsDragging(false);
+
+		const threshold = Math.max(50, getViewportWidth() * 0.15);
+
+		if (Math.abs(dragDelta) > threshold) {
+			if (dragDelta < 0) {
+				handleNext();
+			} else {
+				handlePrev();
+			}
+		}
+
+		setDragDelta(0);
+		setIsTransitionEnabled(true);
+	};
+
+	return (
+		<ErrorBoundary fallback={ErrorFallback}>
+			<Suspense fallback={<Skeleton className={detailSliderStyles.mainImage} />}>
+				<div className={detailSliderStyles.mainImage}>
+					<div
+						ref={viewportRef}
+						style={{ width: '100%', height: '100%' }}
+						onPointerDown={onPointerDown}
+						onPointerMove={onPointerMove}
+						onPointerUp={onPointerUp}
+						onPointerCancel={onPointerUp}
+					>
+						<div
+							ref={null}
+							style={{
+								display: 'flex',
+								width: `${slides.length * 100}%`,
+								transform: `translateX(calc(${-current * 100}% + ${dragDelta}px))`,
+								transition:
+									isDragging || !isTransitionEnabled ? 'none' : `transform ${TRANSITION_MS}ms ease`,
+							}}
+						>
+							{slides.map((item) => (
+								<div key={`${item.id}`} className={detailSliderStyles.slideContainer}>
+									{isLoading && (
+										<Skeleton
+											className={css({
+												position: 'absolute',
+												inset: 0,
+											})}
+										/>
+									)}
+									<img
+										ref={refCallback}
+										data-src={item.url}
+										onLoad={() => setIsLoading(false)}
+										alt={item.id}
+										className={detailSliderStyles.slideImage}
+										draggable={false}
+									/>
+								</div>
+							))}
+						</div>
+					</div>
+
+					<button
+						type='button'
+						className={detailSliderStyles.arrowBtn({ side: 'left' })}
+						onClick={handlePrev}
+					>
+						◀
+					</button>
+					<button
+						type='button'
+						className={detailSliderStyles.arrowBtn({ side: 'right' })}
+						onClick={handleNext}
+					>
+						▶
+					</button>
+
+					<div className={detailSliderStyles.counter}>
+						{current + 1} / {slides.length}
+					</div>
+				</div>
+			</Suspense>
+		</ErrorBoundary>
+	);
+};
+
+export default DetailSlider;

--- a/src/components/detailSlider/styles.ts
+++ b/src/components/detailSlider/styles.ts
@@ -1,0 +1,55 @@
+import { css } from 'styled-system/css';
+
+export const detailSliderStyles = {
+	mainImage: css({
+		position: 'relative',
+		overflow: 'hidden',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		height: { base: '50vh', md: '500px' },
+		width: { base: '100vw', md: '80vw' },
+		marginX: 'auto',
+		pt: '1.5rem',
+	}),
+	slideContainer: css({
+		flex: '0 0 100%',
+		width: '100%',
+		height: '100%',
+		position: 'relative',
+		overflow: 'hidden',
+	}),
+	slideImage: css({
+		width: '80vw',
+		height: { base: '300px', md: '500px' },
+		// objectFit: 'cover',
+		userSelect: 'none',
+		pointerEvents: 'auto',
+		WebkitUserSelect: 'none',
+	}),
+	arrowBtn: (options: { side: 'left' | 'right' }) =>
+		css({
+			position: 'absolute',
+			top: '50%',
+			transform: 'translateY(-50%)',
+			zIndex: 10,
+			bg: 'rgba(0,0,0,0.4)',
+			color: 'white',
+			rounded: 'full',
+			p: '2',
+			cursor: 'pointer',
+			_hover: { bg: 'rgba(0,0,0,0.6)' },
+			...(options.side === 'left' ? { left: '4' } : { right: '4' }),
+		}),
+	counter: css({
+		position: 'absolute',
+		bottom: '3',
+		right: '4',
+		fontSize: 'sm',
+		bg: 'rgba(0,0,0,0.5)',
+		color: 'white',
+		px: '2',
+		py: '1',
+		rounded: 'sm',
+	}),
+};

--- a/src/components/detailSlider/styles.ts
+++ b/src/components/detailSlider/styles.ts
@@ -11,6 +11,7 @@ export const detailSliderStyles = {
 		width: { base: '100vw', md: '80vw' },
 		marginX: 'auto',
 		pt: '1.5rem',
+		mb: '2rem',
 	}),
 	slideContainer: css({
 		flex: '0 0 100%',

--- a/src/pages/detailItem/index.tsx
+++ b/src/pages/detailItem/index.tsx
@@ -1,20 +1,17 @@
 import { ErrorBoundary, Suspense } from '@suspensive/react';
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import type { PortfolioItem } from '@/assets/data/type';
 import { ErrorFallback } from '@/components/common/fallback';
 import DetailBoard from '@/components/detailBoard';
 import DetailSidebar from '@/components/detailSidebar';
-import Metrics from '@/components/detailSidebar/metrics';
+import DetailSlider from '@/components/detailSlider';
 import { useFetch } from '@/hooks/useFetch';
 import { SERVICE_URLS } from '@/utils/ServiceUrls';
 
 import { detailPageStyles } from './styles';
 
 const DetailItem = () => {
-	const [currentImageIndex, setCurrentImageIndex] = useState(0);
-
 	const { id } = useParams();
 
 	const { data } = useFetch<PortfolioItem>({ url: SERVICE_URLS.portfolioItem(id || '') });
@@ -24,15 +21,7 @@ const DetailItem = () => {
 			<Suspense>
 				{data && (
 					<div className={detailPageStyles.container}>
-						<div className={detailPageStyles.imageContainer}>
-							{data.images.length > 0 && (
-								<img
-									src={data.images[currentImageIndex].url}
-									alt={data.images[currentImageIndex].alt}
-									className={detailPageStyles.image}
-								/>
-							)}
-						</div>
+						<DetailSlider imageDatas={data.images} />
 						<div className={detailPageStyles.contentGrid}>
 							<DetailBoard data={data} />
 							<DetailSidebar data={data} />

--- a/src/pages/detailItem/index.tsx
+++ b/src/pages/detailItem/index.tsx
@@ -1,0 +1,46 @@
+import { ErrorBoundary, Suspense } from '@suspensive/react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import type { PortfolioItem } from '@/assets/data/type';
+import { ErrorFallback } from '@/components/common/fallback';
+import DetailBoard from '@/components/detailBoard';
+import DetailSidebar from '@/components/detailSidebar';
+import Metrics from '@/components/detailSidebar/metrics';
+import { useFetch } from '@/hooks/useFetch';
+import { SERVICE_URLS } from '@/utils/ServiceUrls';
+
+import { detailPageStyles } from './styles';
+
+const DetailItem = () => {
+	const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
+	const { id } = useParams();
+
+	const { data } = useFetch<PortfolioItem>({ url: SERVICE_URLS.portfolioItem(id || '') });
+
+	return (
+		<ErrorBoundary fallback={ErrorFallback}>
+			<Suspense>
+				{data && (
+					<div className={detailPageStyles.container}>
+						<div className={detailPageStyles.imageContainer}>
+							{data.images.length > 0 && (
+								<img
+									src={data.images[currentImageIndex].url}
+									alt={data.images[currentImageIndex].alt}
+									className={detailPageStyles.image}
+								/>
+							)}
+						</div>
+						<div className={detailPageStyles.contentGrid}>
+							<DetailBoard data={data} />
+							<DetailSidebar data={data} />
+						</div>
+					</div>
+				)}
+			</Suspense>
+		</ErrorBoundary>
+	);
+};
+export default DetailItem;

--- a/src/pages/detailItem/styles.ts
+++ b/src/pages/detailItem/styles.ts
@@ -1,0 +1,38 @@
+import { css } from 'styled-system/css';
+
+export const detailPageStyles = {
+	container: css({
+		maxW: '80vw',
+		mx: 'auto',
+		px: '4',
+		py: '8',
+	}),
+	imageContainer: css({
+		position: 'relative',
+		mb: '8',
+		rounded: 'lg',
+		overflow: 'hidden',
+		bg: 'gray.100',
+	}),
+	image: css({
+		w: 'full',
+		h: 'full',
+		objectFit: 'cover',
+	}),
+	contentSection: css({
+		display: 'grid',
+		gridTemplateColumns: {
+			base: 'repeat(1, minxmax(100%, 1fr))',
+			'2xl': 'repeat(3,minmax(33%, 1fr))',
+		},
+		gap: '8',
+	}),
+	contentGrid: css({
+		display: 'grid',
+		gridTemplateColumns: {
+			base: '1fr',
+			lg: '2fr 1fr',
+		},
+		gap: '8',
+	}),
+};


### PR DESCRIPTION
### 연관된 이슈

> #62

### 작업 내용

> 작업물 아이템을 조회하는 DetailItem 페이지 개발
- 상단엔 이미지 슬라이더
- 메인 컨텐츠엔 게시글(해당 인테리어 관련 데이터) 영역과 사이드바(회사정보, 매트릭스 등 부가정보) 영역 으로 구분
- 반응형 추가 (사이드바가 아래로 내려옴)

### 스크린샷 (선택)

### 리뷰 요구사항(선택)

> 리뷰어가 참고할만한 기타사항
