### PR TITLE
Fix/57--rendering-error--fix

### DIFF
--- a/mocks/handler.ts
+++ b/mocks/handler.ts
@@ -112,7 +112,7 @@ export const handlers = [
 	}),
 	// 6. 배너 이미지
 	http.get('/api/banners', async () => {
-		await delay(10000);
+		await delay(200);
 
 		return HttpResponse.json({
 			success: true,

--- a/src/components/Banner/Slider.tsx
+++ b/src/components/Banner/Slider.tsx
@@ -1,4 +1,3 @@
-import { ErrorBoundary, Suspense } from '@suspensive/react';
 import { useRef, useState } from 'react';
 
 import type { BannerItems } from '@/assets/data/type';
@@ -7,7 +6,6 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { SERVICE_URLS } from '@/utils/ServiceUrls';
 import { css } from 'styled-system/css';
 
-import { ErrorFallback } from '../common/fallback';
 import { Skeleton } from '../common/skeleton';
 
 import { bannerStyles } from './styles';
@@ -99,11 +97,7 @@ const Slider = () => {
 					}}
 				>
 					{slides.map((item) => (
-						<div
-							key={`${item.id}`}
-							// className={bannerStyles.slideContainer({ total: slides.length })}
-							className={bannerStyles.slideContainer}
-						>
+						<div key={`${item.id}`} className={bannerStyles.slideContainer}>
 							{isLoading && (
 								<Skeleton
 									className={css({
@@ -116,7 +110,6 @@ const Slider = () => {
 								ref={refCallback}
 								data-src={item.images}
 								onLoad={() => setIsLoading(false)}
-								// src={item.images}
 								alt={item.id}
 								className={bannerStyles.slideImage}
 								draggable={false}

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -1,11 +1,6 @@
-import { ErrorBoundary, Suspense } from '@suspensive/react';
-
 import type { CategoryProps } from '@/assets/data/type';
 import { useSuspenseFetchQuery } from '@/hooks/query/useSuspenseFetchQuery';
 import { SERVICE_URLS } from '@/utils/ServiceUrls';
-
-import { ErrorFallback } from '../common/fallback';
-import { Skeleton } from '../common/skeleton';
 
 import CategoryItem from './CategoryItem';
 import { categoryStyles } from './styles';
@@ -16,17 +11,10 @@ const Category = () => {
 	});
 	return (
 		<div className={categoryStyles.categoryContainer}>
-			<ErrorBoundary fallback={ErrorFallback}>
-				{categories &&
-					categories.map((category: CategoryProps) => (
-						<Suspense
-							key={category.id}
-							fallback={<Skeleton className={categoryStyles.cardContainer} />}
-						>
-							<CategoryItem key={category.id} category={category} />
-						</Suspense>
-					))}
-			</ErrorBoundary>
+			{categories &&
+				categories.map((category: CategoryProps) => (
+					<CategoryItem key={category.id} category={category} />
+				))}
 		</div>
 	);
 };

--- a/src/components/Category/styles.ts
+++ b/src/components/Category/styles.ts
@@ -4,6 +4,7 @@ import { css } from 'styled-system/css';
 export const categoryStyles = {
 	categoryContainer: css({
 		display: { base: 'none', md: 'grid' },
+		minH: '240px',
 		gridTemplateColumns: {
 			base: 'repeat(auto-fit, minmax(100px, 1fr))', // 모바일: 더 작은 최소값
 			md: 'repeat(auto-fit, minmax(120px, 1fr))', // 태블릿

--- a/src/components/Portfolio/styles.ts
+++ b/src/components/Portfolio/styles.ts
@@ -6,6 +6,7 @@ export const portfolioStyles = {
 		py: { base: '8', md: '16' },
 		width: '95vw',
 		px: { base: '4', md: '6' },
+		minH: '350px',
 	}),
 	mainContainer: css({
 		borderBottom: '1px solid token(colors.gray.200)',

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -1,4 +1,3 @@
-import { ErrorBoundary, Suspense } from '@suspensive/react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -8,7 +7,6 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { SERVICE_URLS } from '@/utils/ServiceUrls';
 import { css } from 'styled-system/css';
 
-import { ErrorFallback } from '../common/fallback';
 import { Skeleton } from '../common/skeleton';
 
 import { trendPatterns, trendStyles } from './styles';
@@ -22,7 +20,6 @@ const Trend = () => {
 	return (
 		<>
 			<h2 className={trendStyles.title}>🏆 실시간 인기 시공 사례</h2>
-
 			<div className={trendStyles.gridContainer}>
 				{trendItems &&
 					trendItems.map((item) => (

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -3,9 +3,11 @@ import { ErrorBoundary, Suspense } from '@suspensive/react';
 import Banner from '@/components/Banner';
 import { bannerStyles } from '@/components/Banner/styles';
 import Category from '@/components/Category';
+import { categoryStyles } from '@/components/Category/styles';
 import { ErrorFallback } from '@/components/common/fallback';
 import { Skeleton } from '@/components/common/skeleton';
 import Portfolio from '@/components/Portfolio';
+import { portfolioStyles } from '@/components/Portfolio/styles';
 import Trend from '@/components/Trend';
 import { trendStyles } from '@/components/Trend/styles';
 import { css } from 'styled-system/css';
@@ -46,20 +48,27 @@ const Home = () => {
 					</section>
 				</Suspense>
 			</ErrorBoundary>
-
-			{/* <section
-				className={flex({
-					height: '240px',
-					py: { base: '12', md: '20' },
-					px: { base: '4', md: '6' },
-					justifyContent: 'center',
-				})}
-			>
-				<Category />
-			</section>
-			<section>
-				<Portfolio />
-			</section> */}
+			<ErrorBoundary fallback={ErrorFallback}>
+				<Suspense fallback={<Skeleton className={categoryStyles.categoryContainer} />}>
+					<section
+						className={flex({
+							height: '240px',
+							py: { base: '12', md: '20' },
+							px: { base: '4', md: '6' },
+							justifyContent: 'center',
+						})}
+					>
+						<Category />
+					</section>
+				</Suspense>
+			</ErrorBoundary>
+			<ErrorBoundary fallback={ErrorFallback}>
+				<Suspense fallback={<Skeleton className={portfolioStyles.container} />}>
+					<section>
+						<Portfolio />
+					</section>
+				</Suspense>
+			</ErrorBoundary>
 		</div>
 	);
 };


### PR DESCRIPTION
### 연관된 이슈

> #57

### 작업 내용

> 하나의 api가 delay될 때 그 delay 까지 다른 컴포넌트들이 전부 렌더링 되지 않는 현상 해결
- 컴포넌트 내부 Suspense: 세부 Skeleton 용도로만 사용 → 독립성이 보장되지 않을 수 있음

-Home.tsx 상위 Suspense: 각 컴포넌트를 통째로 감싸서, 각 영역별 독립적인 fallback 가능 → 긴 delay API가 다른 영역을 막지 않음

- 원리: Suspense는 가장 가까운 fallback에서 thrown Promise를 처리, 트리 레벨이 낮으면 다른 렌더링에 영향 가능

### 스크린샷 (선택)

### 리뷰 요구사항(선택)

> 리뷰어가 참고할만한 기타사항
