### PR TITLE
상세 아이템 페이지 진입 시 조회수 증가하는 기능 추가

### DIFF
--- a/src/pages/detailItem/detailContents.tsx
+++ b/src/pages/detailItem/detailContents.tsx
@@ -1,16 +1,48 @@
+import { useEffect } from 'react';
+
 import type { PortfolioItem } from '@/assets/data/type';
 import DetailBoard from '@/components/detailBoard';
 import DetailSidebar from '@/components/detailSidebar';
+import type { MetricAction, MetricType } from '@/components/detailSidebar/meticConst';
+import { METRIC_ACTION, METRIC_TYPE } from '@/components/detailSidebar/meticConst';
 import DetailSlider from '@/components/detailSlider';
+import { usePostMutation } from '@/hooks/query/usePostMutation';
 import { useSuspenseFetchQuery } from '@/hooks/query/useSuspenseFetchQuery';
 import { SERVICE_URLS } from '@/utils/ServiceUrls';
 
 import { detailPageStyles } from './styles';
 
+interface ViewPostResponse {
+	success: boolean;
+	newCount: number;
+}
+interface ViewPostParams {
+	itemId: string;
+	metricType: MetricType;
+	action: MetricAction;
+}
+
 export const DetailContent = ({ id }: { id: string }) => {
 	const { data } = useSuspenseFetchQuery<PortfolioItem>({
 		url: SERVICE_URLS.portfolioItem(id),
 	});
+	const { mutate: postView } = usePostMutation<ViewPostResponse, ViewPostParams>({
+		url: SERVICE_URLS.metricUpdate(data?.id),
+	});
+	useEffect(() => {
+		if (data?.id) {
+			const viewed = `viewed+${data.id}`;
+			const hasViewed = sessionStorage.getItem(viewed);
+			if (!hasViewed) {
+				postView({
+					itemId: data.id,
+					metricType: METRIC_TYPE.VIEW,
+					action: METRIC_ACTION.INC,
+				});
+			}
+			sessionStorage.setItem(viewed, 'true');
+		}
+	}, [data?.id, postView]);
 
 	return (
 		<div className={detailPageStyles.container}>


### PR DESCRIPTION
### 연관된 이슈

> #75

### 작업 내용

> 상세 페이지 진입 시 조회수가 증가하는 기능을 추가하였습니다
 - 현재 개발 환경 상 실제 데이터가 변경되진 않음(response의 newCount로 확인)
 - 중복해서 올라가지 않도록 세션스토리지에 플래그를 넣어둠

### 스크린샷 (선택)

### 리뷰 요구사항(선택)

> 리뷰어가 참고할만한 기타사항
