### PR TITLE
fix/--상세페이지 이미지 CSS수정(objectFit-contain 추가)

### DIFF
--- a/src/components/detailSlider/styles.ts
+++ b/src/components/detailSlider/styles.ts
@@ -23,7 +23,7 @@ export const detailSliderStyles = {
 	slideImage: css({
 		width: '80vw',
 		height: { base: '300px', md: '500px' },
-		// objectFit: 'cover',
+		objectFit: 'contain',
 		userSelect: 'none',
 		pointerEvents: 'auto',
 		WebkitUserSelect: 'none',


### PR DESCRIPTION
### 연관된 이슈

> #86

### 작업 내용

> 상세페이지 이미지 CSS수정
- object-fit : contain 추가

### 스크린샷 (선택)

### 리뷰 요구사항(선택)

> 리뷰어가 참고할만한 기타사항
임시 이미지들의 사이즈가 제각각이라 원하는 느낌으로 안나오는 이미지가 있을 수 있음
