### PR TITLE
Fix/90---useQuery-hook-option-update

### DIFF
--- a/mocks/handler.ts
+++ b/mocks/handler.ts
@@ -11,7 +11,7 @@ export const handlers = [
 		const url = new URL(request.url);
 		const category = url.searchParams.get('category');
 
-		await delay(200);
+		await delay(20000);
 
 		const filteredItems =
 			category && category !== 'all'
@@ -28,7 +28,7 @@ export const handlers = [
 		const url = new URL(request.url);
 		const category = url.searchParams.get('category');
 
-		await delay(200);
+		await delay(20000);
 
 		const filteredItems =
 			category && category !== 'all'
@@ -50,7 +50,7 @@ export const handlers = [
 
 	// 2. 특정 포트폴리오 상세 조회
 	http.get('/api/portfolio/:id', async ({ params }) => {
-		await delay(200);
+		await delay(20000);
 
 		const { id } = params;
 		const item = portfolioItems.find((item) => item.id === id);
@@ -67,7 +67,7 @@ export const handlers = [
 
 	// 3. 트렌드 목록 조회
 	http.get('/api/trends', async () => {
-		await delay(200);
+		await delay(20000);
 
 		return HttpResponse.json({
 			success: true,
@@ -77,7 +77,7 @@ export const handlers = [
 
 	// 4.메트릭 업데이트
 	http.post('/api/metric/:id', async ({ params, request }) => {
-		await delay(200);
+		await delay(20000);
 
 		const { id } = params;
 		const body = await request.json();
@@ -143,7 +143,7 @@ export const handlers = [
 
 	// 5. 메인카테고리 목록
 	http.get('/api/main-categories', async () => {
-		await delay(200);
+		await delay(20000);
 
 		return HttpResponse.json({
 			success: true,
@@ -152,7 +152,7 @@ export const handlers = [
 	}),
 	// 5. 전체카테고리 목록
 	http.get('/api/categories', async () => {
-		await delay(200);
+		await delay(20000);
 
 		return HttpResponse.json({
 			success: true,
@@ -161,7 +161,7 @@ export const handlers = [
 	}),
 	// 6. 배너 이미지
 	http.get('/api/banners', async () => {
-		await delay(200);
+		await delay(20000);
 
 		return HttpResponse.json({
 			success: true,

--- a/src/components/Trend/index.tsx
+++ b/src/components/Trend/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import type { TrendProps } from '@/assets/data/type';
+import { useFetchQuery } from '@/hooks/query/useFetchQuery';
 import { useSuspenseFetchQuery } from '@/hooks/query/useSuspenseFetchQuery';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { SERVICE_URLS } from '@/utils/ServiceUrls';
@@ -13,8 +14,12 @@ import { trendPatterns, trendStyles } from './styles';
 
 const Trend = () => {
 	const refCallback = useIntersectionObserver();
-	const { data: trendItems } = useSuspenseFetchQuery<TrendProps[]>({
+	// const { data: trendItems } = useSuspenseFetchQuery<TrendProps[]>({
+	// 	url: SERVICE_URLS.trends,
+	// });
+	const { data: trendItems } = useFetchQuery<TrendProps[]>({
 		url: SERVICE_URLS.trends,
+		enabled: true,
 	});
 	const [isLoading, setIsLoading] = useState(true);
 	return (

--- a/src/components/common/fallback/index.tsx
+++ b/src/components/common/fallback/index.tsx
@@ -1,31 +1,15 @@
 import { css } from 'styled-system/css';
 
-export const LoadingFallback = () => {
-	return (
-		<div
-			className={css({
-				padding: '1rem',
-				color: 'gray.800',
-				w: '100vw',
-				bgColor: 'gray.400',
-			})}
-		>
-			⏳ 로딩 중...
-		</div>
-	);
-};
-
 export const ErrorFallback = ({ error }: { error: Error }) => {
 	return (
 		<div
 			className={css({
 				padding: '1rem',
-				color: 'red',
 				w: '100vw',
 				bgColor: 'gray.400',
 			})}
 		>
-			⚠️ 오류 발생: {error.message}
+			⏳ 로딩 중: {error.message}
 		</div>
 	);
 };

--- a/src/hooks/query/useFetchQuery.ts
+++ b/src/hooks/query/useFetchQuery.ts
@@ -15,7 +15,12 @@ interface UseFetchQueryParams<TData, TError = Error>
  * @example
  * const { data: anyData, isLoading } = useFetchQuery<AnyType>({
  * url : ANY_URL,
+ * ...options
  * });
+ *
+ * @optional
+ * enabled, select ... 등 useQueryOptions 사용 가능
+ *
  */
 export function useFetchQuery<TData>({ url, ...options }: UseFetchQueryParams<TData>) {
 	const query = useQuery<TData, Error>({

--- a/src/hooks/query/useFetchQuery.ts
+++ b/src/hooks/query/useFetchQuery.ts
@@ -1,12 +1,12 @@
+import type { UseQueryOptions } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import { fetcher } from '@/utils/FetchResult';
 
-interface UseFetchQueryParams {
+interface UseFetchQueryParams<TData, TError = Error>
+	extends Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'> {
 	url: string;
-	enabled?: boolean;
 }
-
 /**
  *
  * @returns T - query 결과에 대한 타입
@@ -17,11 +17,11 @@ interface UseFetchQueryParams {
  * url : ANY_URL,
  * });
  */
-export function useFetchQuery<T>({ url, enabled = true }: UseFetchQueryParams) {
-	const query = useQuery<T, Error>({
+export function useFetchQuery<TData>({ url, ...options }: UseFetchQueryParams<TData>) {
+	const query = useQuery<TData, Error>({
 		queryKey: [url],
-		queryFn: () => fetcher<T>(url),
-		enabled,
+		queryFn: () => fetcher<TData>(url),
+		...options,
 	});
 
 	const { data, ...rest } = query;

--- a/src/hooks/query/useSuspenseFetchQuery.ts
+++ b/src/hooks/query/useSuspenseFetchQuery.ts
@@ -1,10 +1,11 @@
+import type { UseQueryOptions } from '@tanstack/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { fetcher } from '@/utils/FetchResult';
 
-interface UseSuspenseFetchQueryParams {
+interface UseSuspenseFetchQueryParams<TData, TError = Error>
+	extends Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'> {
 	url: string;
-	enabled?: boolean;
 }
 
 /**
@@ -13,15 +14,29 @@ interface UseSuspenseFetchQueryParams {
  * @description GET 요청을 처리하며, Suspense모드를 사용하는 react-query Query훅
  *  - react-query v4의 suspense: true 옵션과 동일한 기능
  *
+ * @warning
+ * - 해당 훅을 사용하고 suspense를 활성화 하지 않으면 컴포넌트가 무한로딩됨.
+ * - suspense를 사용하지 않는 경우 useFetchQuery 훅으로 변경하여 사용해야함
+ *
  * @example
  * const { data: anyData, isLoading } = useSuspenseFetchQuery<AnyType>({
  * url : ANY_URL,
+ *  ...options
  * });
+ *
+ *  * @optional
+ * enabled, select ... 등 useQueryOptions 사용 가능
  */
-export function useSuspenseFetchQuery<T>({ url }: UseSuspenseFetchQueryParams) {
-	const query = useSuspenseQuery<T, Error>({
+export function useSuspenseFetchQuery<TData>({
+	url,
+	...options
+}: UseSuspenseFetchQueryParams<TData>) {
+	const query = useSuspenseQuery<TData, Error>({
 		queryKey: [url],
-		queryFn: () => fetcher<T>(url),
+		queryFn: () => {
+			return fetcher<TData>(url);
+		},
+		...options,
 	});
 
 	const { data, ...rest } = query;


### PR DESCRIPTION
### 연관된 이슈

> #90

### 작업 내용

> useQuery 훅의 인터페이스를 열어둠

- useQuery 인터페이스의 querykey, queryFn을 Omit으로 열어둬서 useQueryOptions에 존재하는 옵션들 사용 가능

### 스크린샷 (선택)

### 리뷰 요구사항(선택)

> 리뷰어가 참고할만한 기타사항
